### PR TITLE
Move form_name / guessing logic into Form

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ bin/rails server      # <- check it out at http://localhost:3000
 
 # view the email rendering in-browser:
 bin/rails disclosure_alert:download      # <- download the filings
-# then: go to http://localhost:3000/rails/mailers/alert_mailer/daily_alert
+# then: go to this URL:
+open http://localhost:3000/rails/mailers/alert_mailer/daily_alert
 
 
 # if you subscribe using the web interface, you can generate an email to

--- a/app/helpers/alert_mailer_helper.rb
+++ b/app/helpers/alert_mailer_helper.rb
@@ -11,8 +11,6 @@ module AlertMailerHelper
         .gsub(/(.{3}) ?([[:alpha:]]+)?/i, '\1 <sub>\2</sub>')
         .gsub(' <sub></sub>', '')
         .html_safe
-    elsif form.title =~ /FPPC Form (\d+)/
-      $~[1]
     else
       '???'
     end
@@ -21,7 +19,7 @@ module AlertMailerHelper
   # @param title {Hash} Return value from Form#filer_title
   def format_position_title(title)
     second_part =
-      if title[:position].match(/(commissioner|\bmember\b)/i)
+      if title[:position].match?(/(commissioner|\bmember\b)/i)
         title[:division_board_district] || title[:agency]
       else
         title[:agency].try(:titleize)

--- a/app/lib/forms.rb
+++ b/app/lib/forms.rb
@@ -1,26 +1,42 @@
 module Forms
   def self.from_filings(filing_array)
     filing_array.map do |filing|
-      case filing.form_name
-      when '410'
-        Forms::Form410.new(filing)
-      when '460'
-        Forms::Form460.new(filing)
-      when '700'
-        Forms::Form700.new(filing)
+      case filing.form.to_i
+      when 23
+        Forms::Form410.new(filing, name: '410')
+      when 30
+        Forms::Form460.new(filing, name: '460')
+      when 38 # LCM = Late Contributions Made
+        Forms::BaseForm.new(filing, name: '497 LCM')
+      when 39 # LCR = Late Contributions Received
+        Forms::BaseForm.new(filing, name: '497 LCR')
+      when 199, 215, 220, 228, 254
+        Forms::Form700.new(filing, name: '700')
+      when 236 # LBQ = Oakland Lobbyist Quartery Report
+        Forms::BaseForm.new(filing, name: 'LBQ')
+      when 235 # LBR = Oakland Lobbyist Registration
+        Forms::BaseForm.new(filing, name: 'LBR')
       else
-        Forms::BaseForm.new(filing)
+        guessed_form_name = filing.title.match(/FPPC Form (\d+)/) ? $~[1] : nil
+
+        if filing.form.to_i == 0 && guessed_form_name == '700'
+          Forms::Form700.new(filing, name: guessed_form_name)
+        else
+          Forms::BaseForm.new(filing, name: guessed_form_name)
+        end
       end
     end
   end
 
   class BaseForm
     delegate :id, :filer_id, :title, :filed_at, :amendment_sequence_number,
-             :amended_filing_id, :form, :form_name, :contents, :contents_xml,
+             :amended_filing_id, :form, :contents, :contents_xml,
              to: :@filing
+    attr_reader :form_name
 
-    def initialize(filing)
+    def initialize(filing, name: nil)
       @filing = filing
+      @form_name = name
     end
 
     # Override in a subclass if a better name can be presented to the user.
@@ -42,7 +58,7 @@ module Forms
   end
 
   class BaseXMLForm < BaseForm
-    def initialize(filing)
+    def initialize(filing, name: nil)
       super
 
       @xml = Nokogiri::XML(contents_xml, &:noblanks) if contents_xml.present?

--- a/app/mailers/alert_mailer.rb
+++ b/app/mailers/alert_mailer.rb
@@ -9,7 +9,7 @@ class AlertMailer < ApplicationMailer
 
   def daily_alert(alert_subscriber, date, filings_in_date_range)
     @alert_subscriber = alert_subscriber
-    @filings = Forms.from_filings(filings_in_date_range)
+    @forms = Forms.from_filings(filings_in_date_range)
     @date = date
 
     mail(

--- a/app/models/filing.rb
+++ b/app/models/filing.rb
@@ -3,18 +3,7 @@
 require 'date'
 
 class Filing < ApplicationRecord
-  FORM_IDS = {
-    23 => '410',
-    30 => '460',
-    235 => 'LBR',         # LBR = Oakland Lobbyist Registration
-    236 => 'LBQ',         # LBQ = Oakland Lobbyist Quarterly Report
-    39 => '497 LCR',      # LCR = Late Contributions Received
-    38 => '497 LCM',      # LCM = Late Contributions Made
-    254 => '700',
-  }.freeze
-
   scope :filed_on_date, ->(date) { where(filed_at: date.all_day) }
-  scope :form_number, ->(form) { where(form: FORM_IDS.key(form)) }
 
   def self.from_json(json)
     find_or_initialize_by(id: json['id']) do |record|
@@ -29,6 +18,6 @@ class Filing < ApplicationRecord
   end
 
   def form_name
-    FORM_IDS[form.to_i]
+    Forms.from_filings([self]).first.form_name
   end
 end

--- a/app/views/alert_mailer/daily_alert.html.haml
+++ b/app/views/alert_mailer/daily_alert.html.haml
@@ -1,23 +1,23 @@
 %h3 In Today's Alert Email:
-- grouped_filings = sort_filing_groups(@filings.group_by { |f| f.i18n_key })
+- grouped_forms = sort_filing_groups(@forms.group_by { |f| f.i18n_key })
 
 %ul
-- grouped_filings.each do |i18n_key, filings|
+- grouped_forms.each do |i18n_key, forms|
   %li
-    %b= filings.count
-    =t(i18n_key + '.name', count: filings.count)
+    %b= forms.count
+    =t(i18n_key + '.name', count: forms.count)
 
 %p
 
 %hr
-- grouped_filings.each do |i18n_key, filing_group|
+- grouped_forms.each do |i18n_key, form_group|
   %h2
     %span.filing-group__form-number
       = t(i18n_key + '.label')
     = t(i18n_key + '.name')
     %p= t(i18n_key + '.description_html')
 
-  - filing_group.each do |f|
+  - form_group.each do |f|
     %table.filing
       %tbody
         %tr

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -57,7 +57,7 @@ Rails.application.configure do
   config.assets.quiet = true
 
   # Raises error for missing translations
-  # config.action_view.raise_on_missing_translations = true
+  config.action_view.raise_on_missing_translations = true
 
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -67,6 +67,17 @@ en:
       name: Late Contributions Made Report
       description_html:
         Local committees making contributions totaling more than $1000 in the 90 days before an election are required to file a Form 497 within 24 hours.
+    496:
+      label: Form 496
+      name: Independent Expenditure Report
+      description_html:
+        Independent expenditures totaling over $1000 in support (or
+        opposition) of a candidate or ballot measure must generally be reported
+        using this form. Within 90 days of an election, these expenditures must
+        be reported within 24 hours. For more information on reporting
+        requirements, consult the <a
+        href="http://www.fppc.ca.gov/content/dam/fppc/NS-Documents/TAD/Campaign%20Forms/496.pdf"
+        target="_blank">official California FPPC instructions</a>.
     410:
       label: Form 410
       name: Statement of Organization

--- a/spec/helpers/alert_mailer_helper_spec.rb
+++ b/spec/helpers/alert_mailer_helper_spec.rb
@@ -8,19 +8,15 @@ RSpec.describe AlertMailerHelper do
     let(:form_title) { '' }
     let(:form) { Filing.new(form: form_id, title: form_title) }
 
-    def form_id_for_name(name)
-      Filing::FORM_IDS.detect { |k, v| v == name }[0]
-    end
-
     subject { helper.form_number_html(form) }
 
     describe 'with form type = 460' do
-      let(:form_id) { form_id_for_name('460') }
+      let(:form_id) { 30 }
       it { expect(subject).to eq('460') }
     end
 
     describe 'with form type = 497 LCR' do
-      let(:form_id) { form_id_for_name('497 LCR') }
+      let(:form_id) { 39 }
       it { expect(subject).to eq('497 <sub>LCR</sub>') }
       it { expect(subject).to be_html_safe }
     end
@@ -31,7 +27,7 @@ RSpec.describe AlertMailerHelper do
     end
 
     describe 'with a lobbyist form' do
-      let(:form_id) { form_id_for_name('LBQ') }
+      let(:form_id) { 236 }
       it { expect(subject).to eq('LBQ') }
     end
   end


### PR DESCRIPTION
Previously, the `Filing` class was responsible for converting a Filing
into a Form. But then the logic was somewhat duplicated in Form to
determine which subclass to instantiate.

This centralizes all the logic in Form and moves the `form_name` there.