### PR TITLE
Use "Other Form" label for unsupported forms again

### DIFF
--- a/app/lib/forms.rb
+++ b/app/lib/forms.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Forms
   def self.from_filings(filing_array)
     filing_array.map do |filing|
@@ -51,9 +53,11 @@ module Forms
 
     # I18n key to describe the Form
     def i18n_key
-      return "forms.unknown" unless @filing.form_name.present?
+      return 'forms.unknown' unless @filing.form_name.present?
+      key = "forms.#{@filing.form_name.delete(' ')}"
+      return 'forms.unknown' unless I18n.exists?(key)
 
-      "forms.#{@filing.form_name.delete(' ')}"
+      key
     end
   end
 

--- a/spec/lib/forms_spec.rb
+++ b/spec/lib/forms_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe Forms::BaseForm do
+  describe '#i18n_key' do
+    context 'for a known form' do
+      let(:filing) { Filing.new(form: 23, title: 'FPPC Form 410') }
+      let(:form) { Forms.from_filings([filing]).first }
+
+      it 'returns the correct label for the type' do
+        expect(form.i18n_key).to eq('forms.410')
+      end
+    end
+
+    context 'with an unknown form' do
+      let(:filing) { Filing.new(form: 999, title: 'FPPC Form 999') }
+      let(:form) { Forms.from_filings([filing]).first }
+
+      it 'returns the unknown form label' do
+        expect(form.i18n_key).to eq('forms.unknown')
+      end
+    end
+  end
+end


### PR DESCRIPTION
We added some smarts to guess the form number based on its name. Then,
this bit us when a "FPPC Form 510" came through. The I18n key did not
exist.

This commit updates the I18n logic to check whether the I18n key exists
first.