### PR TITLE
Add links back to OD.io for candidates and referendums

### DIFF
--- a/app/lib/forms.rb
+++ b/app/lib/forms.rb
@@ -59,6 +59,18 @@ module Forms
 
       key
     end
+
+    def spreadsheet_candidate
+      @filing.election_candidates.last
+    end
+
+    def spreadsheet_committee
+      @filing.election_committee
+    end
+
+    def spreadsheet_referendum
+      @filing.election_referendum
+    end
   end
 
   class BaseXMLForm < BaseForm

--- a/app/lib/forms.rb
+++ b/app/lib/forms.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Forms
   def self.from_filings(filing_array)
     filing_array.map do |filing|
@@ -51,9 +53,11 @@ module Forms
 
     # I18n key to describe the Form
     def i18n_key
-      return "forms.unknown" unless @filing.form_name.present?
+      return 'forms.unknown' unless @filing.form_name.present?
+      key = "forms.#{@filing.form_name.delete(' ')}"
+      return 'forms.unknown' unless I18n.exists?(key)
 
-      "forms.#{@filing.form_name.delete(' ')}"
+      key
     end
   end
 

--- a/app/lib/forms/form460.rb
+++ b/app/lib/forms/form460.rb
@@ -29,18 +29,6 @@ module Forms
       Date.new(match[:end_year].to_i, match[:end_month].to_i, match[:end_day].to_i)
     end
 
-    def spreadsheet_candidate
-      @filing.election_candidates.last
-    end
-
-    def spreadsheet_committee
-      @filing.election_committee
-    end
-
-    def spreadsheet_referendum
-      @filing.election_referendum
-    end
-
     private
 
     def contents_row(form_type, line_item)

--- a/app/lib/forms/form460.rb
+++ b/app/lib/forms/form460.rb
@@ -29,6 +29,18 @@ module Forms
       Date.new(match[:end_year].to_i, match[:end_month].to_i, match[:end_day].to_i)
     end
 
+    def spreadsheet_candidate
+      @filing.election_candidates.last
+    end
+
+    def spreadsheet_committee
+      @filing.election_committee
+    end
+
+    def spreadsheet_referendum
+      @filing.election_referendum
+    end
+
     private
 
     def contents_row(form_type, line_item)

--- a/app/lib/slugify.rb
+++ b/app/lib/slugify.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+# Keep this in-sync with disclosure-backend-static and odca-jekyll.
+class Slugify
+  def self.slug(str)
+    I18n
+      .transliterate(str || '')
+      .downcase
+      .gsub(/[^a-z0-9-]+/, '-')
+  end
+end

--- a/app/models/election.rb
+++ b/app/models/election.rb
@@ -42,4 +42,8 @@ class Election < ApplicationRecord
       end
     end
   end
+
+  def locality
+    slug.split('-', 2).first
+  end
 end

--- a/app/models/election_candidate.rb
+++ b/app/models/election_candidate.rb
@@ -5,6 +5,8 @@
 class ElectionCandidate < ApplicationRecord
   CANDIDATE_CSV_URL = 'https://docs.google.com/spreadsheets/d/e/2PACX-1vRZNbqOzI3TlelO3OSh7QGC1Y4rofoRPs0TefWDLJvleFkaXq_6CSWgX89HfxLYrHhy0lr4QqUEryuc/pub?gid=0&single=true&output=csv'
 
+  belongs_to :election, foreign_key: :election_name, primary_key: :slug
+
   def self.replace_all_from_csv(candidate_csv: CANDIDATE_CSV_URL)
     candidate_csv = Net::HTTP.get(URI(candidate_csv)) if candidate_csv.start_with?('http')
     candidates = CSV.parse(candidate_csv, headers: :first_row)
@@ -25,5 +27,9 @@ class ElectionCandidate < ApplicationRecord
         )
       end
     end
+  end
+
+  def opendisclosure_url
+    "https://www.opendisclosure.io/candidate/#{election.locality}/#{election.date}/#{Slugify.slug(name)}"
   end
 end

--- a/app/models/election_committee.rb
+++ b/app/models/election_committee.rb
@@ -1,0 +1,26 @@
+class ElectionCommittee < ApplicationRecord
+  COMMITTEE_CSV_URL = 'https://docs.google.com/spreadsheets/d/e/2PACX-1vRZNbqOzI3TlelO3OSh7QGC1Y4rofoRPs0TefWDLJvleFkaXq_6CSWgX89HfxLYrHhy0lr4QqUEryuc/pub?gid=1015408103&single=true&output=csv'
+
+  def self.replace_all_from_csv(committee_csv: COMMITTEE_CSV_URL)
+    committee_csv = Net::HTTP.get(URI(committee_csv)) if committee_csv.start_with?('http')
+    committees = CSV.parse(committee_csv, headers: :first_row)
+    elections = Election.where(slug: committees.map { |c| c['Ballot Measure Election'] }).index_by(&:slug)
+
+    transaction do
+      destroy_all
+      committees.each do |committee|
+        election = elections[committee['Ballot Measure Election']]
+        next unless election
+
+        create(
+          name: committee['Filer_NamL'],
+          fppc_id: committee['Filer_ID'],
+          candidate_controlled_id: committee['candidate_controlled_id'],
+          support_or_oppose: committee['Support or Oppose'],
+          ballot_measure: committee['Ballot Measure'],
+          ballot_measure_election: committee['Ballot Measure Election'],
+        )
+      end
+    end
+  end
+end

--- a/app/models/election_referendum.rb
+++ b/app/models/election_referendum.rb
@@ -1,6 +1,8 @@
 class ElectionReferendum < ApplicationRecord
   REFERENDUM_CSV_URL = 'https://docs.google.com/spreadsheets/d/e/2PACX-1vRZNbqOzI3TlelO3OSh7QGC1Y4rofoRPs0TefWDLJvleFkaXq_6CSWgX89HfxLYrHhy0lr4QqUEryuc/pub?gid=608094632&single=true&output=csv'
 
+  belongs_to :election, foreign_key: :election_name, primary_key: :slug
+
   def self.replace_all_from_csv(referendum_csv: REFERENDUM_CSV_URL)
     referendum_csv = Net::HTTP.get(URI(referendum_csv)) if referendum_csv.start_with?('http')
 
@@ -21,5 +23,9 @@ class ElectionReferendum < ApplicationRecord
         )
       end
     end
+  end
+
+  def opendisclosure_url
+    "https://www.opendisclosure.io/referendum/#{election.locality}/#{election.date}/#{Slugify.slug(title)}"
   end
 end

--- a/app/views/alert_mailer/_form_460.html.haml
+++ b/app/views/alert_mailer/_form_460.html.haml
@@ -3,4 +3,3 @@
 %br
 %strong Total Expenditures Made:
 = format_money(f.total_expenditures_made)
-

--- a/app/views/alert_mailer/daily_alert.html.haml
+++ b/app/views/alert_mailer/daily_alert.html.haml
@@ -45,8 +45,12 @@
 
         %tr
           %td.filing__actions
+            - if (candidate = f.spreadsheet_candidate)
+              %a.btn{ href: candidate.opendisclosure_url, target: "_blank" } View Candidate on Open Disclosure
+            - elsif (referendum = f.spreadsheet_referendum)
+              %a.btn{ href: referendum.opendisclosure_url, target: "_blank" } View Ballot Measure on Open Disclosure
             - if f.filer_id.present?
-              %a.btn{ href: "https://www.opendisclosure.io/committee/#{f.filer_id}", target: "_blank" } View Committee on Open Disclosure
+              %a.btn{ href: "https://www.opendisclosure.io/committee/#{f.filer_id}", target: "_blank" } View Contributions to this Committee
 
             %a.btn{ href: "https://netfile.com/Connect2/api/public/image/#{f.id}", target: '_blank' }
               View Original Filing

--- a/db/migrate/20200427034305_create_election_committee.rb
+++ b/db/migrate/20200427034305_create_election_committee.rb
@@ -1,0 +1,12 @@
+class CreateElectionCommittee < ActiveRecord::Migration[5.2]
+  def change
+    create_table :election_committees do |t|
+      t.string :name
+      t.string :fppc_id
+      t.string :candidate_controlled_id
+      t.string :support_or_oppose
+      t.string :ballot_measure
+      t.string :ballot_measure_election
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_23_005208) do
+ActiveRecord::Schema.define(version: 2020_04_27_034305) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -69,6 +69,15 @@ ActiveRecord::Schema.define(version: 2020_02_23_005208) do
     t.string "fppc_id"
     t.string "office_name"
     t.boolean "incumbent"
+  end
+
+  create_table "election_committees", force: :cascade do |t|
+    t.string "name"
+    t.string "fppc_id"
+    t.string "candidate_controlled_id"
+    t.string "support_or_oppose"
+    t.string "ballot_measure"
+    t.string "ballot_measure_election"
   end
 
   create_table "election_referendums", force: :cascade do |t|

--- a/lib/tasks/disclosure_alert.rake
+++ b/lib/tasks/disclosure_alert.rake
@@ -31,7 +31,7 @@ namespace :disclosure_alert do
     filings = []
 
     loop do
-      filings = Filing.filed_on_date(today - days_ago)
+      filings = Filing.filed_on_date(today - days_ago).for_email
       break if filings.any?
       days_ago += 1
     end

--- a/lib/tasks/election_csv.rake
+++ b/lib/tasks/election_csv.rake
@@ -4,5 +4,6 @@ namespace :disclosure_alert do
     Election.replace_all_from_csv
     ElectionCandidate.replace_all_from_csv
     ElectionReferendum.replace_all_from_csv
+    ElectionCommittee.replace_all_from_csv
   end
 end

--- a/spec/lib/forms/form460_spec.rb
+++ b/spec/lib/forms/form460_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Forms::Form460 do
+  describe '#spreadsheet_candidate' do
+    context 'with models created according to the spreadsheet' do
+      let(:filer_id) { 123456789 }
+      let!(:election) { Election.create(slug: 'oakland-2020', location: 'foo', title: 'bar', date: '2020-11-03') }
+      let(:filing) { Filing.create(form: 30, filer_id: filer_id) }
+      let(:form) { Forms.from_filings([filing]).first }
+      let!(:election_candidate) { ElectionCandidate.create(election_name: election.slug, fppc_id: filer_id, name: 'Tom McTomface') }
+
+      it 'returns the candidate' do
+        expect(form.spreadsheet_candidate).to eq(election_candidate)
+      end
+    end
+  end
+
+  describe '#spreadsheet_committee' do
+    context 'with models created according to the spreadsheet' do
+      let(:filer_id) { 123456789 }
+      let!(:election) { Election.create(slug: 'oakland-2020', location: 'foo', title: 'bar', date: '2020-11-03') }
+      let(:filing) { Filing.create(form: 30, filer_id: filer_id) }
+      let(:form) { Forms.from_filings([filing]).first }
+      let!(:election_committee) { ElectionCommittee.create(fppc_id: filer_id, name: 'Tom McTomface for Mayor') }
+
+      it 'returns the candidate' do
+        expect(form.spreadsheet_committee).to eq(election_committee)
+      end
+    end
+  end
+
+  describe '#spreadsheet_referendum' do
+    context 'with models created according to the spreadsheet' do
+      let(:filer_id) { 123456789 }
+      let!(:election) { Election.create(slug: 'oakland-2020', location: 'foo', title: 'bar', date: '2020-11-03') }
+      let(:filing) { Filing.create(form: 30, filer_id: filer_id) }
+      let(:form) { Forms.from_filings([filing]).first }
+      let!(:election_committee) do
+        ElectionCommittee.create(
+          fppc_id: filer_id,
+          name: 'Vote Yes on Proposition Tom',
+          ballot_measure: 'T',
+          ballot_measure_election: election.slug,
+        )
+      end
+      let!(:election_referendum) do
+        ElectionReferendum.create(
+          measure_number: 'T',
+          election_name: election.slug,
+          title: 'Proposition T: Toms for Oakland',
+        )
+      end
+
+      it 'returns the referendum' do
+        expect(form.spreadsheet_referendum).to eq(election_referendum)
+      end
+    end
+  end
+end

--- a/spec/lib/forms_spec.rb
+++ b/spec/lib/forms_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe Forms::BaseForm do
+  describe '#i18n_key' do
+    context 'for a known form' do
+      let(:filing) { Filing.new(form: 23, title: 'FPPC Form 410') }
+      let(:form) { Forms.from_filings([filing]).first }
+
+      it 'returns the correct label for the type' do
+        expect(form.i18n_key).to eq('forms.410')
+      end
+    end
+
+    context 'with an unknown form' do
+      let(:filing) { Filing.new(form: 999, title: 'FPPC Form 999') }
+      let(:form) { Forms.from_filings([filing]).first }
+
+      it 'returns the unknown form label' do
+        expect(form.i18n_key).to eq('forms.unknown')
+      end
+    end
+  end
+end

--- a/spec/models/election_committee_spec.rb
+++ b/spec/models/election_committee_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ElectionCommittee do
+  describe '.replace_all_from_csv' do
+    let!(:election) { Election.create(slug: 'oakland-2020', location: 'foo', title: 'bar', date: '2020-11-03') }
+    let(:committee) do
+      {
+        'Filer_ID' => '1419466',
+        'Filer_NamL' => 'Pass Measure C for Oakland',
+        'Ballot Measure' => 'C',
+        'Ballot Measure Election' => election.slug,
+        'Support or Oppose' => 'S',
+        'candidate_controlled_id' => '1234567',
+      }
+    end
+    let(:committees_csv) do
+      CSV.generate(headers: committee.keys, write_headers: true) { |csv| csv << committee }
+    end
+
+    subject { described_class.replace_all_from_csv(committee_csv: committees_csv) }
+
+    it 'creates an ElectionCommittee with the proper data' do
+      ElectionCommittee.destroy_all
+      expect { subject }.to change(ElectionCommittee, :count).by(1)
+      created_committee = ElectionCommittee.last
+      expect(created_committee.ballot_measure).to eq('C')
+      expect(created_committee.ballot_measure_election).to eq('oakland-2020')
+    end
+  end
+end


### PR DESCRIPTION
This branch adds links back to Candidates and Referendums that are in the spreadsheet. For candidates it will say "View Candidate on Open Disclosure" and for Referendums it will say "View Ballot Measure on Open Disclosure". For committees without the associated candidate/referendum, it will just say "View Contributions to this Committee" since that is most accurately what the link will be.

If a candidate or referendum (via a ballot measure committee) is known, we can generate the link to it when we see a filing with the same FPPC ID.