### PR TITLE
Add ManualSend class to back-send previous time ranges

### DIFF
--- a/app/assets/stylesheets/email.scss
+++ b/app/assets/stylesheets/email.scss
@@ -18,6 +18,12 @@ body, html {
     background-color: #fff;
     padding-top: 1px;
   }
+
+  &--notice {
+    padding: 20px;
+    background-color: #fff9d7;
+    border: 1px solid #ffdd1f;
+  }
 }
 
 .email-title {

--- a/app/lib/manual_send.rb
+++ b/app/lib/manual_send.rb
@@ -1,0 +1,56 @@
+# Use in case of emergency.
+#
+# Usage:
+#   send = ManualSend.new(
+#     date_from: Date.new(2020, 9, 12),
+#     date_to: Date.new(2020, 9, 23),
+#     notice: "From 9/12 we had a filing error."
+#   )
+#   send.preview
+#   send.execute!
+#
+class ManualSend
+  def initialize(date_from:, date_to:, notice: nil, tom_only: false)
+    @range = date_from..date_to
+    @notice = notice
+    @tom_only = tom_only
+  end
+
+  def preview
+    puts "Will send to #{subscribers.count} subscribers:"
+    subscribers.each do |subscriber|
+      puts "  * #{subscriber.email}"
+    end
+
+    puts
+    puts "Will send #{filings.count} filings."
+    filings.each do |filing|
+      puts "  * #{filing.filed_at.to_date} - #{filing.title}"
+    end
+
+    puts
+    puts "Sending with notice: #{@notice}" if @notice
+  end
+
+  def execute!
+    subscribers.each do |subscriber|
+      AlertMailer
+        .daily_alert(subscriber, @range, filings, notice: @notice)
+        .deliver_now
+    end
+  end
+
+  private
+
+  def subscribers
+    @subscribers ||= if @tom_only
+                       [AlertSubscriber.find_by(email: 'tomdooner@gmail.com')]
+                     else
+                       AlertSubscriber.subscribed.to_a
+                     end
+  end
+
+  def filings
+    @filings ||= Filing.filed_in_date_range(@range).order(filed_at: :asc).to_a
+  end
+end

--- a/app/mailers/alert_mailer.rb
+++ b/app/mailers/alert_mailer.rb
@@ -7,15 +7,21 @@ class AlertMailer < ApplicationMailer
   track open: true, click: true, utm_params: true,
     user: -> { AlertSubscriber.subscribed.find_by(email: message.to.first) }
 
-  def daily_alert(alert_subscriber, date, filings_in_date_range)
+  def daily_alert(alert_subscriber, date_or_date_range, filings_in_date_range, notice: nil)
     @alert_subscriber = alert_subscriber
     @forms = Forms.from_filings(filings_in_date_range)
-    @date = date
+    @email_notice = notice
+
+    subject_date = if date_or_date_range.is_a?(Range)
+                     "between #{date_or_date_range.min} and #{date_or_date_range.max}"
+                   else
+                     "on #{date_or_date_range}"
+                   end
 
     mail(
       to: @alert_subscriber.email,
       from: 'Open Disclosure Alert <alert@opendisclosure.io>',
-      subject: "New Campaign Disclosure filings on #{@date}",
+      subject: "New Campaign Disclosure filings #{subject_date}",
     )
   end
 end

--- a/app/models/filing.rb
+++ b/app/models/filing.rb
@@ -4,6 +4,7 @@ require 'date'
 
 class Filing < ApplicationRecord
   scope :filed_on_date, ->(date) { where(filed_at: date.all_day) }
+  scope :filed_in_date_range, ->(range) { where(filed_at: range) }
   scope :for_email, -> { includes(:amended_filing, :election_candidates, :election_committee) }
 
   # Find spreadsheet entries related to these entities

--- a/app/views/layouts/mailer.html.haml
+++ b/app/views/layouts/mailer.html.haml
@@ -11,6 +11,13 @@
           .container
             Open Disclosure Alerts
 
+      - if @email_notice
+        %tr
+          %td
+            .container.container--notice
+              %strong Notice:
+              = @email_notice
+
       %tr
         %td
           .container.container--main

--- a/spec/mailers/alert_mailer_spec.rb
+++ b/spec/mailers/alert_mailer_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe AlertMailer do
 
   describe '#daily_alert' do
     let(:alert_subscriber) { AlertSubscriber.create(email: 'tomdooner+test@gmail.com') }
-    let(:date) { Date.yesterday }
+    let(:date) { Date.new(2020, 9, 1) }
     let(:filings_in_date_range) do
       [
         create_filing(id: 1),
@@ -43,8 +43,26 @@ RSpec.describe AlertMailer do
     subject { described_class.daily_alert(alert_subscriber, date, filings_in_date_range) }
 
     it 'renders' do
+      expect(subject.subject).to include('filings on 2020-09-01')
       expect(subject.body.encoded).to include(filings_in_date_range.first.filer_name)
       expect(subject.body.encoded).to include('View Contributions')
+    end
+
+    context 'when giving a date range instead of a single date' do
+      let(:alert_subscriber) { AlertSubscriber.create(email: 'tomdooner+test@gmail.com') }
+      let(:date) { Date.new(2020, 9, 1)..Date.new(2020, 9, 20) }
+      let(:filings_in_date_range) do
+        [
+          create_filing(id: 1),
+          create_filing(id: 2),
+          create_filing(id: 3),
+        ]
+      end
+
+      it 'renders' do
+        expect(subject.subject).to include('between 2020-09-01 and 2020-09-20')
+        expect(subject.body.encoded).to include(filings_in_date_range.first.filer_name)
+      end
     end
   end
 end

--- a/test/mailers/previews/alert_mailer_preview.rb
+++ b/test/mailers/previews/alert_mailer_preview.rb
@@ -6,6 +6,7 @@ class AlertMailerPreview < ActionMailer::Preview
       find_or_create_subscriber,
       Date.yesterday,
       Filing.order(filed_at: :desc).first(30),
+      notice: 'A notice to the user would appear here.',
     )
   end
 


### PR DESCRIPTION
Due to an error, filings between 9/13 and 9/23 didn't go out as planned.
This commit adds a way to back-send the filings for this range like so:

```
  send = ManualSend.new(
    date_from: Date.new(2020, 9, 13),
    date_to: Date.new(2020, 9, 23),
    notice: "Due to a server error, filings submitted between 9/13 and
      9/23 were not sent out via Open Disclosure Alerts. The error has
      been fixed and future filings will be sent out normally. The below
      email contains the filings during that timeframe. We apologize for
      the error and regret the delay."
    )
  send.preview
  send.execute!
```

* Update Filing to find filings within a date range
* Update AlertMailer to alter Email subject for a date range
* Add some tests to capture old and new behavior