### PR TITLE
Combine multiple 496's from same filer

### DIFF
--- a/app/lib/forms/form496.rb
+++ b/app/lib/forms/form496.rb
@@ -3,41 +3,48 @@
 module Forms
   # Form 496: Late Independent Expenditure Report
   class Form496 < BaseForm
-    def total_contributions_received
+    def contributions
       contents
         .find_all { |r| r['form_Type'] == 'F496P3' }
-        .sum { |r| r['calculated_Amount'] }
-    end
-
-    def total_expenditures_made
-      contents
-        .find_all { |r| r['form_Type'] == 'F496' }
-        .sum { |r| r['tran_Amt1'] }
     end
 
     def contribution_count
-      contents.count { |r| r['form_Type'] == 'F496P3' }
-    end
-
-    def expenditure_count
-      contents.count { |r| r['form_Type'] == 'F496' }
+      contributions.count
     end
 
     def largest_contributions
-      contents
-        .find_all { |r| r['form_Type'] == 'F496P3' }
+      contributions
         .sort_by { |i| i['calculated_Amount'] }
         .reverse
         .first(3)
     end
 
+    def total_contributions_received
+      contributions
+        .sum { |r| r['calculated_Amount'] }
+    end
+
+
     def largest_contributions_amount
       largest_contributions.sum { |r| r['calculated_Amount'] }
     end
 
-    def largest_expenditures
+    def expenditures
       contents
         .find_all { |r| r['form_Type'] == 'F496' }
+    end
+
+    def total_expenditures_made
+      expenditures
+        .sum { |r| r['tran_Amt1'] }
+    end
+
+    def expenditure_count
+      expenditures.count
+    end
+
+    def largest_expenditures
+      expenditures
         .sort_by { |i| i['tran_Amt1'] }
         .reverse
         .first(3)
@@ -45,6 +52,19 @@ module Forms
 
     def largest_expenditures_amount
       largest_expenditures.sum { |r| r['tran_Amt1'] }
+    end
+
+    # Form 496's can be combined if they are different filings from the same
+    # filer, and there is at least one contribution reported on both forms.
+    def can_combine_with?(other_form)
+      return false unless other_form.is_a?(Forms::Form496)
+      return false unless id.nil? || id != other_form.id
+      return false unless filer_id == other_form.filer_id
+
+      has_overlapping_contributions = (other_form.contributions & contributions).present?
+      has_no_contributions = (other_form.contributions.empty? && contributions.empty?)
+
+      (has_overlapping_contributions || has_no_contributions)
     end
   end
 end

--- a/app/lib/forms/form496_combined.rb
+++ b/app/lib/forms/form496_combined.rb
@@ -1,0 +1,21 @@
+module Forms
+  class Form496Combined < Form496
+    def initialize(filings, name: nil)
+      super(filings.first, name: name)
+
+      @filings = filings
+    end
+
+    def title
+      "Combination of #{@filings.length} #{super}"
+    end
+
+    def uncombined_filing_ids
+      @filings[1..-1].map(&:id) << @filings.first.id
+    end
+
+    def contents
+      @filings.flat_map(&:contents).uniq
+    end
+  end
+end

--- a/app/views/alert_mailer/daily_alert.html.haml
+++ b/app/views/alert_mailer/daily_alert.html.haml
@@ -29,6 +29,11 @@
               - if f.amended_filing_id
                 &middot;
                 %a{ href: "https://netfile.com/Connect2/api/public/image/#{f.amended_filing_id}" } View Previous Filing
+              - if f.uncombined_filing_ids.present?
+                &middot;
+                View Originals:
+                - f.uncombined_filing_ids.each do |filing_id|
+                  %a{ href: "https://netfile.com/Connect2/api/public/image/#{filing_id}" } ##{filing_id}
 
             %h3.filing__filer-name= f.filer_name
             - if f.filer_title
@@ -36,7 +41,7 @@
               = format_position_title(f.filer_title)
             - if f.form_name == '460'
               = render 'form_460', f: f
-            - if f.form_name == '496'
+            - if f.form_name == '496' || f.form_name == '496 Combined'
               = render 'form_496', f: f
             - if f.form_name == '497 LCR'
               = render 'form_497_lcr', f: f

--- a/config/application.rb
+++ b/config/application.rb
@@ -19,12 +19,13 @@ module DisclosureAlert
       api_key: ENV['MAILGUN_API_KEY'],
       domain: 'mailgun.opendisclosure.io',
     }
-
-    config.assets.precompile << 'email.scss'
-
     config.action_mailer.default_url_options = {
       host: ENV['APP_HOST'],
     }
+    config.action_mailer.preview_path = Rails.root.join('spec', 'mailers', 'previews')
+
+    config.assets.precompile << 'email.scss'
+
 
     config.time_zone = 'Pacific Time (US & Canada)'
 

--- a/spec/lib/forms_spec.rb
+++ b/spec/lib/forms_spec.rb
@@ -20,4 +20,30 @@ RSpec.describe Forms::BaseForm do
       end
     end
   end
+
+  describe '.combine_forms' do
+    let(:filing1) { Filing.new(form: 36, title: 'Oaklanders for a better Oakland', contents: JSON.parse(<<~JSON)) }
+      [
+        {"form_Type":"F496P3","tran_Dscr":"","tran_Date":"2020-10-09T00:00:00.0000000-07:00","calculated_Amount":25000.0,"cand_NamL":null,"sup_Opp_Cd":null,"bal_Name":null,"bal_Num":null,"tran_NamL":"Service Employees International Union Local 1021 Candidate PAC","tran_NamF":"","tran_City":"Sacramento","tran_Zip4":"95814","tran_Emp":"","tran_Occ":"","tran_Amt1":25000.0,"tran_Amt2":0.0,"entity_Cd":"SCC","cmte_Id":"1296948"},
+        {"form_Type":"F496","tran_Dscr":"NEWSPAPER ADVERTISEMENTS","tran_Date":"2020-10-14T00:00:00.0000000-07:00","calculated_Amount":3737.5,"cand_NamL":"ExampleCandidate","sup_Opp_Cd":"S","bal_Name":"","bal_Num":"","tran_NamL":null,"tran_NamF":null,"tran_City":null,"tran_Zip4":null,"tran_Emp":null,"tran_Occ":null,"tran_Amt1":3737.5,"tran_Amt2":null,"entity_Cd":null,"cmte_Id":null}
+      ]
+    JSON
+    let(:filing2) { Filing.new(form: 36, title: 'Oaklanders for a better Oakland', contents: JSON.parse(<<~JSON)) }
+      [
+        {"form_Type":"F496P3","tran_Dscr":"","tran_Date":"2020-10-09T00:00:00.0000000-07:00","calculated_Amount":25000.0,"cand_NamL":null,"sup_Opp_Cd":null,"bal_Name":null,"bal_Num":null,"tran_NamL":"Service Employees International Union Local 1021 Candidate PAC","tran_NamF":"","tran_City":"Sacramento","tran_Zip4":"95814","tran_Emp":"","tran_Occ":"","tran_Amt1":25000.0,"tran_Amt2":0.0,"entity_Cd":"SCC","cmte_Id":"1296948"},
+        {"form_Type":"F496","tran_Dscr":"PHONE CALLS","tran_Date":"2020-10-09T00:00:00.0000000-07:00","calculated_Amount":5830.5,"cand_NamL":"OtherCandidate","sup_Opp_Cd":"S","bal_Name":"","bal_Num":"","tran_NamL":null,"tran_NamF":null,"tran_City":null,"tran_Zip4":null,"tran_Emp":null,"tran_Occ":null,"tran_Amt1":5830.5,"tran_Amt2":null,"entity_Cd":null,"cmte_Id":null}
+      ]
+    JSON
+
+    context 'with two 496 IE forms 496 IE forms with different expenditures' do
+      it 'merges the forms together' do
+        result = Forms.combine_forms(Forms.from_filings([filing1, filing2]))
+        expect(result.length).to eq(1)
+        combined_form = result.first
+        expect(combined_form).to be_a(Forms::Form496Combined)
+        expect(combined_form.contributions.length).to eq(1)
+        expect(combined_form.expenditures.length).to eq(2)
+      end
+    end
+  end
 end

--- a/spec/mailers/previews/alert_mailer_preview.rb
+++ b/spec/mailers/previews/alert_mailer_preview.rb
@@ -6,7 +6,7 @@ class AlertMailerPreview < ActionMailer::Preview
       find_or_create_subscriber,
       Date.yesterday,
       Filing.order(filed_at: :desc).first(30),
-      notice: 'A notice to the user would appear here.',
+      notice('A notice to the user would appear here.'),
     )
   end
 
@@ -16,5 +16,13 @@ class AlertMailerPreview < ActionMailer::Preview
     AlertSubscriber
       .where(email: 'test+preview@example.com')
       .first_or_create
+  end
+
+  def notice(text)
+    Notice.new(
+      creator: AdminUser.first,
+      date: Date.yesterday,
+      body: text,
+    )
   end
 end


### PR DESCRIPTION
This is the first attempt at editorializing the data somewhat: due to
filing quirks, it appears that Independent Expenditure committees
supporting or opposing multiple candidates typically file a separate
496 for each candidate supported or opposed. This clogs up the alert
email with largely repetitive and sometimes misleading information
(because the contributions are typically reported on all 496 forms).

Forms will be combined for display if they are from the same filer, and
both have either no contributions, or at least one contribution in
common with each other.

In the future this functionality will be used to remove multiple
amendments from the same update email as well (#20).

Closes #41.