### PR TITLE
Fix spacing after filer positions

### DIFF
--- a/app/assets/stylesheets/new_filings_email.scss
+++ b/app/assets/stylesheets/new_filings_email.scss
@@ -20,6 +20,10 @@
   margin-bottom: 1em;
 }
 
+.filing__filer-position {
+  margin-top: -1em;
+}
+
 .filing__metadata {
   color: #666;
   margin: 20px 0 5px 0;

--- a/app/views/alert_mailer/daily_alert.html.haml
+++ b/app/views/alert_mailer/daily_alert.html.haml
@@ -37,8 +37,7 @@
 
             %h3.filing__filer-name= f.filer_name
             - if f.filer_title
-              %br
-              = format_position_title(f.filer_title)
+              %p.filing__filer-position= format_position_title(f.filer_title)
             - if f.form_name == '460'
               = render 'form_460', f: f
             - if f.form_name == '496' || f.form_name == '496 Combined'


### PR DESCRIPTION
On Form 700's, the linebreak was before the position instead of after. I
also changed the spacing to move the position right next the filer name.

Thanks for the bug report @mikeubell 