### PR TITLE
Add ability to modify subscription frequency

### DIFF
--- a/app/mailers/alert_mailer.rb
+++ b/app/mailers/alert_mailer.rb
@@ -9,11 +9,15 @@ class AlertMailer < ApplicationMailer
     @forms = Forms.from_filings(filings)
     @email_notice = notice
 
-    subject_date = if date_or_date_range.is_a?(Range)
-                     "between #{date_or_date_range.min} and #{date_or_date_range.max}"
-                   else
-                     "on #{date_or_date_range}"
-                   end
+    subject_date =
+      if date_or_date_range.is_a?(Date)
+        "on #{date_or_date_range}"
+      else
+        start_date = date_or_date_range.min.to_date
+        end_date = date_or_date_range.max.to_date
+
+        "between #{start_date} and #{end_date}"
+      end
 
     mail(
       to: @alert_subscriber.email,

--- a/app/models/alert_subscriber.rb
+++ b/app/models/alert_subscriber.rb
@@ -21,6 +21,8 @@ class AlertSubscriber < ApplicationRecord
   belongs_to :netfile_agency
   has_many :sent_messages
 
+  enum subscription_frequency: { daily: 0, weekly: 1 }
+
   validates :email, format: /\A[^@]+@[^\.]+\.[\w]+\z/i
 
   before_save :set_token_if_missing

--- a/db/migrate/20250205053954_add_subscription_frequency_to_alert_subscribers.rb
+++ b/db/migrate/20250205053954_add_subscription_frequency_to_alert_subscribers.rb
@@ -1,0 +1,5 @@
+class AddSubscriptionFrequencyToAlertSubscribers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :alert_subscribers, :subscription_frequency, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_10_21_234640) do
+ActiveRecord::Schema[7.0].define(version: 2025_02_05_053954) do
   # These are extensions that must be enabled in order to support this database
+  enable_extension "pg_stat_statements"
   enable_extension "plpgsql"
 
   create_table "active_admin_comments", force: :cascade do |t|
@@ -61,6 +62,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_21_234640) do
     t.datetime "unsubscribed_at", precision: nil
     t.datetime "confirmed_at", precision: nil
     t.bigint "netfile_agency_id", default: 1
+    t.integer "subscription_frequency", default: 0
     t.index ["netfile_agency_id"], name: "index_alert_subscribers_on_netfile_agency_id"
     t.index ["token"], name: "index_alert_subscribers_on_token"
   end

--- a/spec/lib/disclosure_emailer_spec.rb
+++ b/spec/lib/disclosure_emailer_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe DisclosureEmailer do
   describe '#send_email' do
-    let(:today) { Date.parse('2022-10-01') }
+    let(:yesterday) { Date.parse('2022-10-01') }
     let(:subscribed_agency) { NetfileAgency.coak }
     let(:filing_agency) { NetfileAgency.coak }
     let!(:subscriber) do
@@ -12,11 +12,11 @@ describe DisclosureEmailer do
         netfile_agency: subscribed_agency,
       )
     end
-    let(:filed_at) { today.beginning_of_day.change(hour: 10) }
+    let(:filed_at) { yesterday.beginning_of_day.change(hour: 10) }
     let!(:filing) { Filing.create(filer_id: 123, filed_at: filed_at, form: 30, netfile_agency: filing_agency) }
-    let!(:valid_filing) { Filing.create(filer_id: 123, filed_at: today.beginning_of_day.change(hour: 10), form: 30, netfile_agency: subscribed_agency) }
+    let!(:valid_filing) { Filing.create(filer_id: 123, filed_at: yesterday.beginning_of_day.change(hour: 10), form: 30, netfile_agency: subscribed_agency) }
 
-    subject { described_class.new(today).send_email }
+    subject { described_class.new(yesterday).send_email }
 
     before do
       allow(AlertMailer).to receive(:daily_alert).and_return(double(deliver_now: nil))
@@ -28,18 +28,18 @@ describe DisclosureEmailer do
         subject
         expect(AlertMailer)
           .to have_received(:daily_alert)
-          .with(subscriber, today, include(filing), anything)
+          .with(subscriber, yesterday, include(filing), anything)
       end
     end
 
     context 'when the filing is for a different date' do
-      let(:filed_at) { today - 1.day }
+      let(:filed_at) { yesterday - 1.day }
 
       it 'excludes the filing' do
         subject
         expect(AlertMailer)
           .to have_received(:daily_alert)
-          .with(subscriber, today, exclude(filing), anything)
+          .with(subscriber, yesterday, exclude(filing), anything)
       end
     end
 
@@ -50,10 +50,38 @@ describe DisclosureEmailer do
         subject
         expect(AlertMailer)
           .to have_received(:daily_alert)
-          .with(subscriber, today, exclude(filing), anything)
+          .with(subscriber, yesterday, exclude(filing), anything)
         expect(AlertMailer)
           .not_to have_received(:daily_alert)
-          .with(subscriber, today, include(filing), anything)
+          .with(subscriber, yesterday, include(filing), anything)
+      end
+    end
+
+    context 'when the subscriber is sent to weekly frequency' do
+      before do
+        subscriber.update(subscription_frequency: 'weekly')
+      end
+
+      context 'on non-Mondays' do
+        it 'does not send an email' do
+          subject
+          expect(AlertMailer)
+            .not_to have_received(:daily_alert)
+            .with(subscriber, anything, anything, anything)
+        end
+      end
+
+      context 'on Monday' do
+        # When sending Monday's email, yesterday was a Sunday:
+        let(:yesterday) { Date.parse('2022-10-02') }
+        let(:filed_at) { yesterday - 3.days }
+
+        it 'sends an email including filings from the past week' do
+          subject
+          expect(AlertMailer)
+            .to have_received(:daily_alert)
+            .with(subscriber, yesterday, include(filing), anything)
+        end
       end
     end
   end

--- a/spec/mailers/alert_mailer_spec.rb
+++ b/spec/mailers/alert_mailer_spec.rb
@@ -137,7 +137,7 @@ RSpec.describe AlertMailer do
 
     context 'when a notice is in effect for the email' do
       let(:notice_creator) { AdminUser.create(email: 'tomdooner@example.com') }
-      let(:notice) { Notice.create(creator: notice_creator, body: notice_body, date: date) }
+      let(:notice) { Notice.create!(creator: notice_creator, body: notice_body, date: date) }
       let(:notice_body) { 'Eat your <strong>fruits</strong> and vegetables!' }
 
       it 'renders the notice in the email' do


### PR DESCRIPTION
Don't want an email every day? Here's a way to dial down the frequency.

This is backend-only for now as I test it. A future commit will add the frontend ability to select your desired frequency (and modify it after initial subscription.)