### PR TITLE
Rescue 500 errors from NetFile while downloading

### DIFF
--- a/app/lib/disclosure_downloader.rb
+++ b/app/lib/disclosure_downloader.rb
@@ -107,6 +107,10 @@ class DisclosureDownloader
       end
 
     filing.update(contents: contents, contents_xml: contents_xml)
+  rescue Netfile::Client::InternalServerError => ex
+    @logger.puts "Error downloading filing #{filing.id}: #{ex}. Marking as failed and continuing."
+
+    filing.update(contents: { error: ex, message: ex.message })
   rescue StandardError => ex
     user_input = retry?(ex)
     retry if user_input == :retry

--- a/app/lib/forms.rb
+++ b/app/lib/forms.rb
@@ -124,6 +124,10 @@ module Forms
     def can_combine_with?(_other_form)
       false
     end
+
+    def download_error?
+      contents.is_a?(Hash) && contents.key?("error")
+    end
   end
 
   class BaseXMLForm < BaseForm

--- a/app/views/alert_mailer/daily_alert.html.haml
+++ b/app/views/alert_mailer/daily_alert.html.haml
@@ -38,14 +38,19 @@
             %h3.filing__filer-name= f.filer_name
             - if f.filer_title
               %p.filing__filer-position= format_position_title(f.filer_title)
-            - if f.form_name == '460'
-              = render 'form_460', f: f
-            - if f.form_name == '496' || f.form_name == '496 Combined'
-              = render 'form_496', f: f
-            - if f.form_name == '497'
-              = render 'form_497', f: f
-            - if f.form_name == '700'
-              = render 'form_700', f: f
+            - if f.download_error?
+              %em
+                A NetFile error occurred while downloading this filing. Check
+                NetFile or the local agency to receive a copy of this filing.
+            - else
+              - if f.form_name == '460'
+                = render 'form_460', f: f
+              - if f.form_name == '496' || f.form_name == '496 Combined'
+                = render 'form_496', f: f
+              - if f.form_name == '497'
+                = render 'form_497', f: f
+              - if f.form_name == '700'
+                = render 'form_700', f: f
 
         %tr
           %td.filing__actions

--- a/spec/mailers/alert_mailer_spec.rb
+++ b/spec/mailers/alert_mailer_spec.rb
@@ -135,6 +135,22 @@ RSpec.describe AlertMailer do
       end
     end
 
+    context 'when there is a filing that fails to download' do
+      let(:filings_in_date_range) do
+        [
+          create_filing(id: 1),
+          create_filing(id: 2, contents: { error: "Net::HTTPInternalServerError", message: "Foo" }),
+        ]
+      end
+
+      it 'renders' do
+        expect(subject.subject).to include('filings on 2020-09-01')
+        expect(subject.body.encoded).to include(filings_in_date_range.first.filer_name)
+        expect(subject.body.encoded).to include(filings_in_date_range.second.filer_name)
+        expect(subject.body.encoded).to include("A NetFile error occurred")
+      end
+    end
+
     context 'when a notice is in effect for the email' do
       let(:notice_creator) { AdminUser.create(email: 'tomdooner@example.com') }
       let(:notice) { Notice.create!(creator: notice_creator, body: notice_body, date: date) }


### PR DESCRIPTION
These have been happening somewhat regularly. Let's catch them and store
their error in the database.

<img width="912" alt="image" src="https://github.com/user-attachments/assets/d9b38108-84c6-4b8a-b183-7984922ea1b6" />
