### PR TITLE
Limit deadlines atop email to 90 days

### DIFF
--- a/app/mailers/alert_mailer.rb
+++ b/app/mailers/alert_mailer.rb
@@ -14,7 +14,7 @@ class AlertMailer < ApplicationMailer
     @alert_subscriber = alert_subscriber
     @forms = Forms.from_filings(filings)
     @email_notice = notices_for_subscriber(alert_subscriber, send_date)
-    @upcoming_deadlines = FilingDeadline.future.relevant_to_agency(alert_subscriber.netfile_agency)
+    @upcoming_deadlines = FilingDeadline.future.but_not_too_future.relevant_to_agency(alert_subscriber.netfile_agency)
 
     mail(
       to: @alert_subscriber.email,

--- a/app/models/filing_deadline.rb
+++ b/app/models/filing_deadline.rb
@@ -4,6 +4,7 @@ class FilingDeadline < ApplicationRecord
   enum deadline_type: [:semi_annual, :late_contribution_window, :pre_election]
 
   scope :future, -> { where('date > ?', Date.today) }
+  scope :but_not_too_future, -> { where('date < ?', 90.days.from_now) }
   scope :relevant_to_agency, ->(agency) do
     future.where(netfile_agency_id: nil).or(
       future.where(netfile_agency_id: agency.netfile_id)


### PR DESCRIPTION
I just put in a years' worth of deadlines. We only need 3 months' worth. Maybe I'll up this to 6 months depending on how it looks.