### PR TITLE
Minimize Form 700 entries that report < $150,000

### DIFF
--- a/app/lib/forms.rb
+++ b/app/lib/forms.rb
@@ -125,6 +125,10 @@ module Forms
       false
     end
 
+    def minimize?
+      false
+    end
+
     def download_error?
       contents.is_a?(Hash) && contents.key?("error")
     end

--- a/app/mailers/alert_mailer.rb
+++ b/app/mailers/alert_mailer.rb
@@ -30,7 +30,8 @@ class AlertMailer < ApplicationMailer
 
     filings = Filing
       .where(netfile_agency: alert_subscriber.netfile_agency)
-      .includes(:election_candidates, :election_committee, :amended_filing)
+      .includes(:election_candidates, :election_committee, :election_referendum, :amended_filing)
+      .without_annoying_sf_forms # TODO: Make this a subscription preference if people really want the firehose.
 
     if date_or_range.is_a?(Date)
       filings.filed_on_date(date_or_range)

--- a/app/models/filing.rb
+++ b/app/models/filing.rb
@@ -6,6 +6,11 @@ class Filing < ApplicationRecord
   scope :filed_on_date, ->(date) { where(filed_at: date.all_day) }
   scope :filed_in_date_range, ->(range) { where(filed_at: range) }
   scope :for_email, -> { includes(:amended_filing, :election_candidates, :election_committee) }
+  scope :without_annoying_sf_forms, -> do
+    where.not("form = ? AND (title like ? OR title like ?)", "0", "Certificate of Ethics Training Form%", "Sunshine Training Declaration%")
+      .where.not(form: '238') # SFO Lobbyist Registration
+      .where.not(form: '258') # San Francisco Individual Lobbyist Statement 
+  end
 
   # Find spreadsheet entries related to these entities
   has_many :election_candidates, foreign_key: :fppc_id, primary_key: :filer_id

--- a/app/views/alert_mailer/_form_700.html.haml
+++ b/app/views/alert_mailer/_form_700.html.haml
@@ -6,18 +6,17 @@
 - if f.schedule_a1.any?
   Investments (Schedule A1):
   %ul
-    - f.schedule_a1.each do |investment|
-      %li #{investment['name_of_business_entity']} - #{investment['fair_market_value']}
+    = format_investments_list(f.schedule_a1)
 - if f.schedule_a2.any?
   Trusts/Business Entities (Schedule A2):
   %ul
     - f.schedule_a2.each do |entity|
-      %li #{entity['entity_name']} (#{entity['business_type']}) - Valued #{entity['fair_market_value_schedule_a_2']}
+      %li #{entity['entity_name']} (#{entity['business_type']}) - Valued #{format_value_range(entity['fair_market_value_schedule_a_2'])}
 - if f.schedule_b.any?
   Real Property (Schedule B):
   %ul
     - f.schedule_b.each do |property|
-      %li #{property['parcel_or_address']}, #{property['city']} - #{property['fair_market_value']}
+      %li #{property['parcel_or_address']}, #{property['city']} - #{format_value_range(property['fair_market_value'])}
 - if f.schedule_c1.any?
   Income, Loans, and Business Positions (Schedule C):
   %ul
@@ -26,11 +25,8 @@
         = income['name_of_income_source']
         - if income['business_position'].present? || income['business_activity'].present?
           = surround '(', ')' do
-            %span<>= income['business_position']
-            - if income['business_activity']
-              = precede ', ' do
-                = income['business_activity'].strip
-        \- #{income['gross_income_received_schedule_c_1']}
+            = [income['business_position'], income['business_activity']].map(&:presence).compact.join(", ")
+        \- #{format_value_range(income['gross_income_received_schedule_c_1'])}
 - if f.schedule_d.any?
   Gifts (Schedule D):
   %ul

--- a/app/views/alert_mailer/daily_alert.html.haml
+++ b/app/views/alert_mailer/daily_alert.html.haml
@@ -33,7 +33,8 @@
     = t(i18n_key + '.name')
     %p= t(i18n_key + '.description_html')
 
-  - form_group.each do |f|
+  - minimized, full_size = form_group.partition(&:minimize?)
+  - full_size.each do |f|
     %table.filing
       %tbody
         %tr
@@ -84,6 +85,14 @@
             %p.filing__metadata
               Filed at
               = f.filed_at.strftime("%A %B %e, %Y at %I:%M %P")
+
+  - if minimized.any?
+    Additionally, these #{minimized.length} filings did not appear to contain any significant data:
+    - minimized.sort_by { |f| f.filer_name }.each do |f|
+      = succeed "," do
+        %a{ href: "https://netfile.com/Connect2/api/public/image/#{f.id}", target: "_blank", style: "color: inherit" }<>
+          = f.filer_name
+
 
 %hr
 

--- a/spec/mailers/previews/alert_mailer_preview.rb
+++ b/spec/mailers/previews/alert_mailer_preview.rb
@@ -15,11 +15,18 @@ class AlertMailerPreview < ActionMailer::Preview
     )
   end
 
+  def daily_alert_last_week_sfo
+    AlertMailer.daily_alert(
+      find_or_create_subscriber(NetfileAgency.sfo),
+      Date.today.last_week.all_week,
+    )
+  end
+
   private
 
-  def find_or_create_subscriber
+  def find_or_create_subscriber(agency = NetfileAgency.coak)
     AlertSubscriber
-      .where(email: 'test+preview@example.com')
+      .where(email: 'test+preview@example.com', netfile_agency: agency)
       .first_or_create
   end
 end


### PR DESCRIPTION
* Add support for "minimizing" a form when rendering it in the email. This means it will be displayed as just a simple text link after all the other filings in its group.

* Convert the Form 700 dollar-value ranges from a string into a struct that maintains the min & max range. This will allow combining across all items.

* Minimize Form 700 entries that are < $150,000 in max reported value. These forms are voluminous from SF, and the vast majority of folks don't have anything interesting to report. I think I don't really care about investments that are less than a reasonable Bay Area salary. (Maybe I should treat gifts differently, on theory they are more influential than the dollar value suggests?)

* Also, hide Form 700 investments after the 5th one (sorted by value), since sometimes people disclose a humongous list of investments.

* Finally, hide a couple SF forms that are really noisy: Ethics Training
  and Lobbyist Registration. Someday I will add the ability to opt-in to
  still receiving those.