### PR TITLE
Allow previewing alert mailers from the homepage

### DIFF
--- a/app/controllers/alert_previews_controller.rb
+++ b/app/controllers/alert_previews_controller.rb
@@ -1,0 +1,19 @@
+class AlertPreviewsController < ApplicationController
+  def show
+    @email_date = case params[:date]
+                  when "today"
+                    Time.zone.today
+                  when "yesterday"
+                    Time.zone.yesterday
+                  end
+
+    @forms = Forms.from_filings(
+      Filing
+        .filed_on_date(@email_date - 1)
+        .where(netfile_agency: NetfileAgency.coak)
+        .for_email
+    )
+    @upcoming_deadlines = FilingDeadline.future.but_not_too_future
+      .relevant_to_agency(NetfileAgency.coak)
+  end
+end

--- a/app/controllers/alert_subscribers_controller.rb
+++ b/app/controllers/alert_subscribers_controller.rb
@@ -3,6 +3,9 @@ class AlertSubscribersController < ApplicationController
 
   def new
     @alert_subscriber = AlertSubscriber.new
+
+    @can_preview_today = Filing.filed_on_date(Date.yesterday).where(netfile_agency: NetfileAgency.coak).any?
+    @can_preview_yesterday = Filing.filed_on_date(Date.yesterday - 1).where(netfile_agency: NetfileAgency.coak).any?
   end
 
   def create

--- a/app/views/alert_mailer/daily_alert.html.haml
+++ b/app/views/alert_mailer/daily_alert.html.haml
@@ -31,7 +31,7 @@
     %span.filing-group__form-number
       = t(i18n_key + '.label')
     = t(i18n_key + '.name')
-    %p= t(i18n_key + '.description_html')
+  %p= t(i18n_key + '.description_html')
 
   - minimized, full_size = form_group.partition(&:minimize?)
   - full_size.each do |f|
@@ -61,13 +61,13 @@
                 NetFile or the local agency to receive a copy of this filing.
             - else
               - if f.form_name == '460'
-                = render 'form_460', f: f
+                = render 'alert_mailer/form_460', f: f
               - if f.form_name == '496' || f.form_name == '496 Combined'
-                = render 'form_496', f: f
+                = render 'alert_mailer/form_496', f: f
               - if f.form_name == '497' || f.form_name == '497 Combined'
-                = render 'form_497', f: f
+                = render 'alert_mailer/form_497', f: f
               - if f.form_name == '700'
-                = render 'form_700', f: f
+                = render 'alert_mailer/form_700', f: f
 
         %tr
           %td.filing__actions
@@ -100,14 +100,3 @@
   For more information about filing deadlines,
   = link_to 'consult the California FPPC', 'https://www.fppc.ca.gov/learn/campaign-rules/where-and-when-to-file-campaign-statements/when-to-file-campaign-statements-state-local-filing-schedules.html'
   or the local campaign finance agency.
-
-%p
-  Was this email useful?
-  = link_to 'Yes', 'https://docs.google.com/forms/d/e/1FAIpQLSeRo2RUDjd9rbv1azDsiYezliKr0JbxbTfWvWgEBbKrUsklZA/viewform?usp=pp_url&entry.2039237906=Yes', 'disable-tracking' => true
-  \/
-  = link_to 'No', 'https://docs.google.com/forms/d/e/1FAIpQLSeRo2RUDjd9rbv1azDsiYezliKr0JbxbTfWvWgEBbKrUsklZA/viewform?usp=pp_url&entry.2039237906=No', 'disable-tracking' => true
-
-%p
-  Want to unsubscribe or receive fewer emails?
-  = link_to 'Update Delivery Preferences',
-    edit_alert_subscriber_url(@alert_subscriber, token: @alert_subscriber.token)

--- a/app/views/alert_previews/show.html.haml
+++ b/app/views/alert_previews/show.html.haml
@@ -1,0 +1,25 @@
+= stylesheet_link_tag 'email'
+
+-# Override some stylings to make this preview not ugly:
+:css
+  .filing {
+    display: block;
+  }
+  .email-preview-container {
+    font-size: 1.6rem;
+  }
+
+%main.main{"aria-label" => "Content"}
+  .container.container--informational
+    .grid
+      .grid-col-12
+        %strong Note:
+        This is a preview of the email sent on #{@email_date.strftime("%B %d, %Y")}.
+
+        = link_to "Subscribe to alert emails", new_alert_subscriber_path
+        to ensure you won't miss an email like this in the future.
+
+  .container.email-preview-container
+    .grid
+      .grid-col-12
+        = render template: "alert_mailer/daily_alert"

--- a/app/views/alert_subscribers/new.html.haml
+++ b/app/views/alert_subscribers/new.html.haml
@@ -22,3 +22,16 @@
             %li Donations to campaign committees and lobbyists' activity
             %li Spending by Political Action Committees (PACs) and third-parties (Independent Expenditures)
             %li Economic interests of, and requests to contribute to charities by city officials
+
+      .grid-col-12
+        %p
+          We'll never share your email or send you unwanted junk.
+          - if @can_preview_today || @can_preview_yesterday
+            See
+            - if @can_preview_today
+              = link_to "today's email", alert_preview_path("today"), style: 'color: inherit; text-decoration: underline;'
+            - if @can_preview_yesterday && @can_preview_today
+              or
+            - if @can_preview_yesterday
+              = link_to "yesterday's email", alert_preview_path("yesterday"), style: 'color: inherit; text-decoration: underline;'
+            for examples of the types of information included in the email.

--- a/app/views/layouts/mailer.html.haml
+++ b/app/views/layouts/mailer.html.haml
@@ -26,3 +26,15 @@
         %td
           .container.container--main
             = yield
+
+            %p
+              Was this email useful?
+              = link_to 'Yes', 'https://docs.google.com/forms/d/e/1FAIpQLSeRo2RUDjd9rbv1azDsiYezliKr0JbxbTfWvWgEBbKrUsklZA/viewform?usp=pp_url&entry.2039237906=Yes', 'disable-tracking' => true
+              \/
+              = link_to 'No', 'https://docs.google.com/forms/d/e/1FAIpQLSeRo2RUDjd9rbv1azDsiYezliKr0JbxbTfWvWgEBbKrUsklZA/viewform?usp=pp_url&entry.2039237906=No', 'disable-tracking' => true
+
+            - if @alert_subscriber
+              %p
+                Want to unsubscribe or receive fewer emails?
+                = link_to 'Update Delivery Preferences',
+                  edit_alert_subscriber_url(@alert_subscriber, token: @alert_subscriber.token)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,8 @@ Rails.application.routes.draw do
 
   post '/webhooks/mailgun', to: 'webhooks#mailgun'
 
+  get '/alert_preview/:date', to: 'alert_previews#show', as: :alert_preview
+
   resources :alert_subscribers, only: %i[new create edit destroy update] do
     get 'confirm', on: :member
 

--- a/spec/controllers/alert_previews_controller_spec.rb
+++ b/spec/controllers/alert_previews_controller_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe AlertPreviewsController do
+  render_views
+
+  describe '#show' do
+    let(:yesterday) { Time.zone.now.to_date.yesterday }
+    let!(:filings) do
+      [
+        Filing.create!(
+          id: 100_000,
+          filer_id: 333_333,
+          filer_name: 'Oakland for better Oaklanders',
+          title: 'FPPC Form 496',
+          filed_at: yesterday,
+          amendment_sequence_number: '0',
+          amended_filing_id: nil,
+          netfile_agency: NetfileAgency.coak,
+          form: 36, # FPPC 496
+          contents: [],
+        ),
+        Filing.create!(
+          id: 100_001,
+          filer_id: 333_333,
+          filer_name: 'Oakland for better Oaklanders',
+          title: 'FPPC Form 496',
+          filed_at: yesterday,
+          amendment_sequence_number: '0',
+          amended_filing_id: nil,
+          netfile_agency: NetfileAgency.coak,
+          form: 36, # FPPC 496
+          contents: [],
+        ),
+      ]
+    end
+
+    it "renders successfully" do
+      get :show, params: { date: "today" }
+
+      expect(response).to be_successful
+      expect(response.body).to include("Oakland for better Oaklanders")
+    end
+  end
+end


### PR DESCRIPTION
Maybe it's a low-commitment way to see what's up before making the plunge to subscribe?

![image](https://github.com/user-attachments/assets/03581cb8-9c99-4c3b-a862-41faf25cab1a)
