### PR TITLE
Never unsubscribe our only user

### DIFF
--- a/app/controllers/webhooks_controller.rb
+++ b/app/controllers/webhooks_controller.rb
@@ -2,8 +2,13 @@ class WebhooksController < ApplicationController
   skip_before_action :verify_authenticity_token
   before_action :verify_mailgun_signature
 
-  UNSUBSCRIBE_THRESHOLD = 2 # messages, within...
+  UNSUBSCRIBE_THRESHOLD = 3 # failures, within...
   UNSUBSCRIBE_LOOKBACK = 1.month
+
+  # Never unsubscribe these user IDs for 'failed' events. This is super hacky
+  # but I'd rather try a narrow blocklist like this than add a column to the
+  # database just for this.
+  NEVER_UNSUBCRIBE_SUBSCRIBER_IDS = [35]
 
   def mailgun
     data = params[:'event-data']
@@ -57,14 +62,9 @@ class WebhooksController < ApplicationController
     subscribers = AlertSubscriber.subscribed.where(email: recipient)
     # Leave a note in the admin interface
     subscribers.find_each do |subscriber|
-      comment = ActiveAdmin::Comment.create(
-        resource: subscriber,
-        author: AdminUser.first,
-        namespace: 'admin',
-        body: <<~BODY,
-          Unsubscribed via Mailgun webhook: #{event}
-        BODY
-      )
+      create_comment(subscriber, <<~BODY)
+        Unsubscribed via Mailgun webhook: #{event}
+      BODY
     end
     subscribers.update_all(unsubscribed_at: Time.now)
   end
@@ -73,15 +73,17 @@ class WebhooksController < ApplicationController
     subscribers = AlertSubscriber.subscribed.where(email: recipient)
     subscribers.find_each do |subscriber|
       previous_failure_count = subscriber.sent_messages.bounced.where('sent_at > ?', UNSUBSCRIBE_LOOKBACK.ago).count
-      if previous_failure_count >= UNSUBSCRIBE_THRESHOLD
-        ActiveAdmin::Comment.create(
-          resource: subscriber,
-          author: AdminUser.first,
-          namespace: 'admin',
-          body: <<~BODY,
-            Unsubscribed for #{UNSUBSCRIBE_THRESHOLD} failures (event: #{event}) within lookback period.
-          BODY
-        )
+      next unless previous_failure_count >= UNSUBSCRIBE_THRESHOLD
+
+      if NEVER_UNSUBCRIBE_SUBSCRIBER_IDS.include?(subscriber.id)
+        create_comment(subscriber, <<~BODY)
+          Would have unsubscribed for #{UNSUBSCRIBE_THRESHOLD} failures (event: #{event}) within lookback period, but didn't because ID is in NEVER_UNSUBCRIBE_SUBSCRIBER_IDS.
+        BODY
+      else
+        create_comment(subscriber, <<~BODY)
+          Unsubscribed for #{UNSUBSCRIBE_THRESHOLD} failures (event: #{event}) within lookback period.
+        BODY
+
         subscriber.touch(:unsubscribed_at)
       end
     end
@@ -96,5 +98,14 @@ class WebhooksController < ApplicationController
     is_valid = signature_params[:signature] == OpenSSL::HMAC.hexdigest(digest, ENV['MAILGUN_SIGNING_KEY'], data)
 
     return head :unauthorized unless is_valid
+  end
+
+  def create_comment(subscriber, body)
+    ActiveAdmin::Comment.create(
+      resource: subscriber,
+      author: AdminUser.first,
+      namespace: 'admin',
+      body: body,
+    )
   end
 end


### PR DESCRIPTION
We have one power user (our only user?) who keeps getting unsubscribed
due to sporadic email bounces.

Let's hack in a blocklist of IDs so those IDs will never be
unsubscribed. I'll also update the threshold for everyone else.
